### PR TITLE
Add ajax_required custom decorator

### DIFF
--- a/common/decorators.py
+++ b/common/decorators.py
@@ -1,0 +1,12 @@
+from django.http import HttpResponseBadRequest
+
+
+def ajax_required(f):
+    def wrap(request, *args, **kwargs):
+        if not request.is_ajax():
+            return HttpResponseBadRequest("AJAX request required")
+        return f(request, *args, **kwargs)
+
+    wrap.__doc__ = f.__doc__
+    wrap.__name__ = f.__name__
+    return wrap

--- a/images/views.py
+++ b/images/views.py
@@ -4,6 +4,8 @@ from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_POST
 
+from common.decorators import ajax_required
+
 from .forms import ImageCreateForm
 from .models import Image
 
@@ -32,6 +34,7 @@ def image_detail(request, id, slug):
     )
 
 
+@ajax_required
 @login_required
 @require_POST
 def image_like(request):


### PR DESCRIPTION
Implemented ajax_required decorator in common/decorators.py to ensure views respond only to AJAX requests. The decorator checks the HTTP_X_REQUESTED_WITH header and returns a 400 error if the request is not AJAX.

Applied this decorator to the image_like view in views.py to enforce AJAX-only access for the like functionality. This update improves security by limiting direct browser access to specific endpoints.